### PR TITLE
Fix postHandshake called too late for OpenSSL

### DIFF
--- a/src/dtlssrtptransport.hpp
+++ b/src/dtlssrtptransport.hpp
@@ -26,6 +26,8 @@
 
 #include <srtp2/srtp.h>
 
+#include <atomic>
+
 namespace rtc {
 
 class DtlsSrtpTransport final : public DtlsTransport {
@@ -39,7 +41,7 @@ public:
 	~DtlsSrtpTransport();
 
 	bool sendMedia(message_ptr message);
-    void addSSRC(uint32_t ssrc);
+	void addSSRC(uint32_t ssrc);
 
 private:
 	void incoming(message_ptr message) override;
@@ -48,10 +50,10 @@ private:
 	message_callback mSrtpRecvCallback;
 
 	srtp_t mSrtpIn, mSrtpOut;
-	bool mInitDone = false;
 
-    unsigned char mClientSessionKey[SRTP_AES_ICM_128_KEY_LEN_WSALT];
-    unsigned char mServerSessionKey[SRTP_AES_ICM_128_KEY_LEN_WSALT];
+	std::atomic<bool> mInitDone = false;
+	unsigned char mClientSessionKey[SRTP_AES_ICM_128_KEY_LEN_WSALT];
+	unsigned char mServerSessionKey[SRTP_AES_ICM_128_KEY_LEN_WSALT];
 };
 
 } // namespace rtc

--- a/src/dtlstransport.cpp
+++ b/src/dtlstransport.cpp
@@ -453,8 +453,8 @@ void DtlsTransport::runRecvLoop() {
 						SSL_set_mtu(mSsl, maxMtu + 1);
 
 						PLOG_INFO << "DTLS handshake finished";
-						changeState(State::Connected);
 						postHandshake();
+						changeState(State::Connected);
 					}
 				} else {
 					ret = SSL_read(mSsl, buffer, bufferSize);


### PR DESCRIPTION
This PR fixes `postHandshake()` call order for OpenSSL and adds related check.